### PR TITLE
Drop SCM version

### DIFF
--- a/autobuild.xml
+++ b/autobuild.xml
@@ -15,8 +15,6 @@
       <string>LICENSES/zlib-ng.txt</string>
       <key>name</key>
       <string>zlib-ng</string>
-      <key>use_scm_version</key>
-      <boolean>true</boolean>
       <key>platforms</key>
       <map>
         <key>common</key>
@@ -117,6 +115,8 @@
           <string>windows</string>
         </map>
       </map>
+      <key>version_file</key>
+      <string>VERSION.txt</string>
     </map>
     <key>type</key>
     <string>autobuild</string>


### PR DESCRIPTION
SCM (tag-based) does not play well with branches yet. Furthermore, as long as we add BUILD_ID to the version we can safely use the upstream version for releases.