### PR TITLE
Update zlib-ng to 2.2.2 and fix macOS ARM64 support

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,7 +8,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [windows-2022, macos-12, ubuntu-22.04]
+        os: [windows-2022, macos-15, ubuntu-22.04]
         addrsize: ["64"]
     runs-on: ${{ matrix.os }}
     steps:
@@ -22,7 +22,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get -y install ninja-build
-      - uses: secondlife/action-autobuild@v4
+      - uses: secondlife/action-autobuild@v5
         with:
           addrsize: ${{ matrix.addrsize }}
   release:

--- a/patches/fix-macos-arm64-and-win-build.patch
+++ b/patches/fix-macos-arm64-and-win-build.patch
@@ -1,0 +1,66 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index fba3575d..c0bd04fd 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -193,7 +193,7 @@ elseif(MSVC)
+     # /Oi ?
+     set(WARNFLAGS /W3 /w34242 /WX)
+     set(WARNFLAGS_MAINTAINER /W4)
+-    set(WARNFLAGS_DISABLE /wd4206 /wd4054)
++    set(WARNFLAGS_DISABLE /wd4206 /wd4054 /wd4267)
+     if(BASEARCH_ARM_FOUND)
+         add_definitions(-D_ARM_WINAPI_PARTITION_DESKTOP_SDK_AVAILABLE)
+         if(NOT "${ARCH}" MATCHES "aarch64")
+@@ -216,7 +216,7 @@ elseif(CMAKE_C_COMPILER_ID MATCHES "GNU" OR CMAKE_C_COMPILER_ID MATCHES "Clang")
+     endif()
+     if(NOT WITH_NATIVE_INSTRUCTIONS)
+         if(BASEARCH_ARM_FOUND)
+-            if("${ARCH}" MATCHES "arm" AND NOT CMAKE_C_FLAGS MATCHES "-mfloat-abi")
++            if("${ARCH}" MATCHES "arm" AND NOT "${ARCH}" MATCHES "arm64" AND NOT CMAKE_C_FLAGS MATCHES "-mfloat-abi")
+                 # Auto-detect support for ARM floating point ABI
+                 check_include_file(features.h HAVE_FEATURES_H)
+                 if(HAVE_FEATURES_H)
+diff --git a/cmake/detect-arch.cmake b/cmake/detect-arch.cmake
+index dfdc6013..a021550b 100644
+--- a/cmake/detect-arch.cmake
++++ b/cmake/detect-arch.cmake
+@@ -51,7 +51,7 @@ endif()
+ if("${ARCH}" MATCHES "(x86_64|AMD64|i[3-6]86)")
+     set(BASEARCH "x86")
+     set(BASEARCH_X86_FOUND TRUE)
+-elseif("${ARCH}" MATCHES "(arm(v[0-9])?|aarch64|cortex)")
++elseif("${ARCH}" MATCHES "(arm(v[0-9])?|arm64|aarch64|cortex)")
+     set(BASEARCH "arm")
+     set(BASEARCH_ARM_FOUND TRUE)
+ elseif("${ARCH}" MATCHES "ppc(64(le)?)?|powerpc(64(le)?)?")
+diff --git a/cmake/detect-intrinsics.cmake b/cmake/detect-intrinsics.cmake
+index 1906f215..593b3123 100644
+--- a/cmake/detect-intrinsics.cmake
++++ b/cmake/detect-intrinsics.cmake
+@@ -178,7 +178,7 @@ endmacro()
+ macro(check_neon_compiler_flag)
+     if(NOT NATIVEFLAG)
+         if(CMAKE_C_COMPILER_ID MATCHES "GNU" OR CMAKE_C_COMPILER_ID MATCHES "Clang")
+-            if("${ARCH}" MATCHES "aarch64")
++            if("${ARCH}" MATCHES "aarch64" OR "${ARCH}" MATCHES "arm64")
+                 set(NEONFLAG "-march=armv8-a+simd")
+             else()
+                 set(NEONFLAG "-mfpu=neon")
+@@ -197,7 +197,7 @@ macro(check_neon_compiler_flag)
+         NEON_AVAILABLE FAIL_REGEX "not supported")
+     # Check whether compiler native flag is enough for NEON support
+     # Some GCC versions don't enable FPU (vector unit) when using -march=native
+-    if(NEON_AVAILABLE AND NATIVEFLAG AND (NOT "${ARCH}" MATCHES "aarch64"))
++    if(NEON_AVAILABLE AND NATIVEFLAG AND (NOT "${ARCH}" MATCHES "aarch64") AND  (NOT "${ARCH}" MATCHES "arm64"))
+         check_c_source_compiles(
+             "#include <arm_neon.h>
+             uint8x16_t f(uint8x16_t x, uint8x16_t y) {
+@@ -241,7 +241,7 @@ endmacro()
+ macro(check_neon_ld4_intrinsics)
+     if(NOT NATIVEFLAG)
+         if(CMAKE_C_COMPILER_ID MATCHES "GNU" OR CMAKE_C_COMPILER_ID MATCHES "Clang")
+-            if("${ARCH}" MATCHES "aarch64")
++            if("${ARCH}" MATCHES "aarch64" OR "${ARCH}" MATCHES "arm64")
+                 set(NEONFLAG "-march=armv8-a+simd")
+             else()
+                 set(NEONFLAG "-mfpu=neon")


### PR DESCRIPTION
* Update to zlib-ng 2.2.2 for bug/stability fixes
* Fixes macos arm64 build and simd support